### PR TITLE
Ignore high-entropy words in whitelist

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,42 +15,59 @@ const simpleEntropy = (str) => {
   }, 0)
 }
 
-const file = process.argv[2]
-if (!file) {
-  console.error('You need to provide a file as an argument')
-  process.exit(1)
+const whitelist = fs.readFileSync(path.resolve(__dirname, './whitelist'), 'utf8').split('\n')
+
+const isWordASecret = (word) => {
+  if (whitelist.includes(word)) {
+    return false
+  }
+  const entropy = simpleEntropy(word)
+  if (entropy > 4) {
+    return true
+  }
 }
 
-const fullpath = path.isAbsolute(file) ? file : path.join(process.cwd(), file)
-if (path.basename(fullpath).startsWith('.env')) {
-  console.log('Ignoring file', fullpath)
-  process.exit()
-}
-try {
-  const source = fs.readFileSync(fullpath, 'utf8')
-  const lines = source.split('\n')
-  if (lines[0] && lines[0].includes('findsecrets-ignore-file')) {
-    process.exit()
+if (require.main !== module) {
+  module.exports = {
+    isWordASecret,
   }
-  const errors = lines.reduce((errors, line, lineNumber) => {
-    if (line.includes('findsecrets-ignore-line')) {
-      return errors
-    }
-    const words = line.split(/\W+/)
-    words.forEach(word => {
-      const entropy = simpleEntropy(word)
-      if (entropy > 4) {
-        errors.push(`    at line ${lineNumber + 1} ${word.substring(0, word.length / 2 + 1)}...`)
-      }
-    }, false)
-    return errors
-  }, [])
-  if (errors.length > 0) {
-    console.error('Found secrets in', fullpath)
-    errors.forEach(error => console.error(error))
+} else {
+  const file = process.argv[2]
+  if (!file) {
+    console.error('You need to provide a file as an argument')
     process.exit(1)
   }
-} catch (err) {
-  console.error('Error', err.stack || err.message || String(err))
-  process.exit(1)
+
+  const fullpath = path.isAbsolute(file) ? file : path.join(process.cwd(), file)
+  if (path.basename(fullpath).startsWith('.env')) {
+    console.log('Ignoring file', fullpath)
+    process.exit()
+  }
+  try {
+    const source = fs.readFileSync(fullpath, 'utf8')
+    const lines = source.split('\n')
+    if (lines[0] && lines[0].includes('findsecrets-ignore-file')) {
+      process.exit()
+    }
+    const errors = lines.reduce((errors, line, lineNumber) => {
+      if (line.includes('findsecrets-ignore-line')) {
+        return errors
+      }
+      const words = line.split(/\W+/)
+      words.forEach(word => {
+        if (isWordASecret(word)) {
+          errors.push(`    at line ${lineNumber + 1} ${word.substring(0, word.length / 2 + 1)}...`)
+        }
+      }, false)
+      return errors
+    }, [])
+    if (errors.length > 0) {
+      console.error('Found secrets in', fullpath)
+      errors.forEach(error => console.error(error))
+      process.exit(1)
+    }
+  } catch (err) {
+    console.error('Error', err.stack || err.message || String(err))
+    process.exit(1)
+  }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,11 @@
+const app = require('./')
+
+describe('isWordASecret', () => {
+  it('should flag these', () => {
+    expect(app.isWordASecret('ZVyyCKt7i2JMtlaJgnYExjRyBlI1KOHbxiDcseWQ9at5uHFvQl')).toBe(true)
+  })
+
+  it('should not flag these', () => {
+    expect(app.isWordASecret('dangerouslySetInnerHTML')).toBe(false)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Prevent pushing secrets to the repository",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "bin": {
     "findsecrets": "./index.js"
@@ -13,5 +13,7 @@
   "author": "Alberto Gimeno <gimenete@gimenete.net>",
   "license": "MIT",
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "jest": "^23.6.0"
+  }
 }

--- a/whitelist
+++ b/whitelist
@@ -1,0 +1,1 @@
+dangerouslySetInnerHTML


### PR DESCRIPTION
This addresses #2, adding a whitelist for similar instances in the future.  The structure was changed a tiny bit to treat the script as a module when run by other code to allow for tests (hence all the whitespace diff).